### PR TITLE
Add support for Rust 1.26.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Travis CI script. See https://travis-ci.org/ for more info.
+
+language: rust
+rust:
+    - stable
+    - 1.26.2
+    - beta
+    - nightly
+matrix:
+    allow_failures:
+        # We try to be compatible with beta and nightly, but they occasionally
+        # fail, so we don't allow them to hold up people using stable.
+        - rust: beta
+        - rust: nightly
+    # Similarly, we don't need to hold up people using stable while we wait
+    # for the results which may fail.
+    fast_finish: true
+dist: trusty
+sudo: false
+cache: cargo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 rustc\_apfloat
 ==============
 
+![minimum rustc 1.26](https://img.shields.io/badge/rustc-1.26+-red.svg)
+
 This is Rust Project's [rustc\_apfloat library], extracted into a standalone
 crate, as suggested in [#43554].
 

--- a/src/ieee.rs
+++ b/src/ieee.rs
@@ -2320,7 +2320,7 @@ mod sig {
 
     /// One, not zero, based MSB. That is, returns 0 for a zeroed significand.
     pub(super) fn omsb(limbs: &[Limb]) -> usize {
-        limbs.iter().enumerate().rfind(|(_, &limb)| limb != 0).map_or(0,
+        limbs.iter().enumerate().rev().find(|(_, &limb)| limb != 0).map_or(0,
             |(i, limb)| (i + 1) * LIMB_BITS - limb.leading_zeros() as usize)
     }
 


### PR DESCRIPTION
This also adds a basic .travis.yml.