### PR TITLE
Fix to_bits and from_bits for X87DoubleExtended

### DIFF
--- a/src/ieee.rs
+++ b/src/ieee.rs
@@ -201,7 +201,7 @@ impl Semantics for X87DoubleExtendedS {
         let sign = bits & (1 << (Self::BITS - 1));
         let exponent = (bits & !sign) >> Self::PRECISION;
         let mut r = IeeeFloat {
-            sig: [bits & ((1 << (Self::PRECISION - 1)) - 1)],
+            sig: [bits & ((1 << Self::PRECISION) - 1)],
             // Convert the exponent from its bias representation to a signed integer.
             exp: (exponent as ExpInt) - Self::MAX_EXP,
             category: Category::Zero,

--- a/tests/ieee.rs
+++ b/tests/ieee.rs
@@ -6887,3 +6887,47 @@ fn modulo() {
         assert_eq!(status, Status::INVALID_OP);
     }
 }
+
+#[test]
+fn roundtrip() {
+    let f1 = Half::from_str_r("3.14159265358979323", Round::TowardZero).unwrap().value;
+    let bits1 = Half::to_bits(f1);
+    let f2 = Half::from_bits(bits1);
+    let bits2 = Half::to_bits(f2);
+    assert_eq!(bits1, bits2);
+    assert_eq!(f1, f2);
+
+    let f1 = Single::from_str_r("3.14159265358979323", Round::TowardZero).unwrap().value;
+    let bits1 = Single::to_bits(f1);
+    let f2 = Single::from_bits(bits1);
+    let bits2 = Single::to_bits(f2);
+    assert_eq!(bits1, bits2);
+    assert_eq!(f1, f2);
+
+    let f1 = Double::from_str_r("3.14159265358979323", Round::TowardZero).unwrap().value;
+    let bits1 = Double::to_bits(f1);
+    let f2 = Double::from_bits(bits1);
+    let bits2 = Double::to_bits(f2);
+    assert_eq!(bits1, bits2);
+    assert_eq!(f1, f2);
+
+    let f1 = Quad::from_str_r("3.14159265358979323", Round::TowardZero).unwrap().value;
+    let bits1 = Quad::to_bits(f1);
+    let f2 = Quad::from_bits(bits1);
+    let bits2 = Quad::to_bits(f2);
+    assert_eq!(bits1, bits2);
+    assert_eq!(f1, f2);
+
+    let f1 = X87DoubleExtended::from_str_r("3.14159265358979323", Round::TowardZero).unwrap().value;
+    let bits1 = X87DoubleExtended::to_bits(f1);
+    let f2 = X87DoubleExtended::from_bits(bits1);
+    let bits2 = X87DoubleExtended::to_bits(f2);
+    assert_eq!(bits1, bits2);
+    assert_eq!(f1, f2);
+}
+
+#[test]
+fn from_bits() {
+    let f1 = X87DoubleExtended::from_bits(0x4000C90FDAA22168C235);
+    assert_eq!(&f1.to_string(), "3.14159265358979323851");
+}


### PR DESCRIPTION
When trying to use this crate, I noticed that conversion to and from x87 80-bit floating points did not work correctly. In particular, doing a roundtrip via `X87DoubleExtended::from_bits(X87DoubleExtended::to_bits(...))` would yield a different result.

I have added a test and tried to fix the bug. My knowledge of floating points is limited, so if you want to merge please double-check that the changes I have made are correct!